### PR TITLE
gnome-boxes: update to 44.3

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,10 +1,10 @@
 name       : gnome-boxes
-version    : '44.2'
-release    : 57
+version    : '44.3'
+release    : 58
 source     :
-    - https://download.gnome.org/sources/gnome-boxes/44/gnome-boxes-44.2.tar.xz : 9dd389c149d0c0fa57456ec363d51a88255f945558fb9df42894ce78ef85df89
-homepage   : https://apps.gnome.org/app/org.gnome.Boxes/
+    - https://download.gnome.org/sources/gnome-boxes/44/gnome-boxes-44.3.tar.xz : 648a41b8e0c875f04e3a787ea67036bc921e858a36e6343a43db7242ee73e171
 license    : GPL-2.0-only
+homepage   : https://apps.gnome.org/app/org.gnome.Boxes/
 component  : desktop.gnome
 summary    : A simple GNOME 3 application to access remote or virtual systems.
 description: |

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-boxes</Name>
         <Homepage>https://apps.gnome.org/app/org.gnome.Boxes/</Homepage>
         <Packager>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.gnome</PartOf>
@@ -745,7 +745,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="57">gnome-boxes</Dependency>
+            <Dependency release="58">gnome-boxes</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gnome-boxes/govf/govf-disk.h</Path>
@@ -754,12 +754,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="57">
-            <Date>2023-07-18</Date>
-            <Version>44.2</Version>
+        <Update release="58">
+            <Date>2023-09-17</Date>
+            <Version>44.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Changes:**
- Fix issues with sensitivity of "create" button
- Mark Shell search-provider to not autostart
- Improve OS download error reporting
- Improve handling when KVM is not available
- Fix VM creation when setting `G_MESSAGES_DEBUG` env var
- Fix current-memory property not updated when changing VM RAM preference
- Various appdata fixes and improvements
- Added/updated/fixed translations

**Test Plan:**
- Launched and used existing VMs
- Created, modified and deleted new VMs

### Checklist

- [x] Package was built and tested against unstable
